### PR TITLE
Power consumption

### DIFF
--- a/keyboards/vortex/boards/VORTEX_DUAL_60/board.c
+++ b/keyboards/vortex/boards/VORTEX_DUAL_60/board.c
@@ -36,6 +36,22 @@
     PBIT(PORT, LINE_ROW8) | \
     PBIT(PORT, LINE_ROW9) | \
     PBIT(PORT, LINE_SPI_CS) | \
+    PBIT(PORT, LINE_LED_SHIFT_DATA) | \
+    PBIT(PORT, LINE_LED_SHIFT_CLK) | \
+    PBIT(PORT, LINE_LED_SHIFT_CLR) | \
+    PBIT(PORT, LINE_TROW1) | \
+    PBIT(PORT, LINE_TCOL1) | \
+    PBIT(PORT, LINE_TCOL2) | \
+    PBIT(PORT, LINE_TCOL3) | \
+    PBIT(PORT, LINE_TCOL4) | \
+    PBIT(PORT, LINE_TCOL5) | \
+    PBIT(PORT, LINE_TCOL6) | \
+    PBIT(PORT, LINE_TCOL7) | \
+    PBIT(PORT, LINE_TCOL8) | \
+    PBIT(PORT, LINE_LED_VOLTAGE) | \
+    PBIT(PORT, LINE_OD_RED1) | \
+    PBIT(PORT, LINE_OD_RED2) | \
+    PBIT(PORT, LINE_OD_RED3) | \
 0)
 
 #define IN_BITS(PORT) (\
@@ -47,6 +63,13 @@
     PBIT(PORT, LINE_COL6) | \
     PBIT(PORT, LINE_COL7) | \
     PBIT(PORT, LINE_COL8) | \
+0)
+
+#define OD_BITS(PORT) (\
+    PBIT(PORT, LINE_LED_VOLTAGE) | \
+    PBIT(PORT, LINE_OD_RED1) | \
+    PBIT(PORT, LINE_OD_RED2) | \
+    PBIT(PORT, LINE_OD_RED3) | \
 0)
 
 #define AF_BITS(PORT, N) (\
@@ -71,6 +94,22 @@
     PAFIO(PORT, N, LINE_SPI_MOSI, AFIO_SPI)  | \
     PAFIO(PORT, N, LINE_SPI_MISO, AFIO_SPI)  | \
     PAFIO(PORT, N, LINE_SPI_CS,   AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_SHIFT_DATA, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_SHIFT_CLK, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_SHIFT_CLR, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TROW1, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL1, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL2, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL3, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL4, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL5, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL6, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL7, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL8, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_VOLTAGE, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_OD_RED1, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_OD_RED2, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_OD_RED3, AFIO_GPIO) | \
 0)
 
 /**
@@ -85,7 +124,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTA),
         .PU = IN_BITS(IOPORTA),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTA),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -98,7 +137,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTB),
         .PU = IN_BITS(IOPORTB),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTB),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -111,7 +150,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTC),
         .PU = IN_BITS(IOPORTC),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTC),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -124,7 +163,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTD),
         .PU = IN_BITS(IOPORTD),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTD),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -137,7 +176,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTE),
         .PU = IN_BITS(IOPORTE),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTE),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -242,4 +281,5 @@ void boardInit(void) {
 #if HAL_USE_UART == TRUE
     uart_init();
 #endif
+    palSetLine(LINE_LED_VOLTAGE); //led voltage off after boot
 }

--- a/keyboards/vortex/boards/VORTEX_DUAL_60/board.c
+++ b/keyboards/vortex/boards/VORTEX_DUAL_60/board.c
@@ -112,6 +112,38 @@
     PAFIO(PORT, N, LINE_OD_RED3, AFIO_GPIO) | \
 0)
 
+#define PESSR_L(LINE) ((PAL_PAD(LINE) < 8) ? (HT32_PAL_IDX(LINE) << (PAL_PAD(LINE) * 4uL)) : 0)
+#define PESSR_H(LINE) ((PAL_PAD(LINE) >=8) ? (HT32_PAL_IDX(LINE) << ((PAL_PAD(LINE) - 8uL) * 4uL)) : 0)
+
+/* doesn't work due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=4210 */
+/*
+#define PESSR(N, LINE) ((N) ? (PESSR_H(LINE)) : (PESSR_L(LINE)))
+#define ESSR_BITS(N) (\
+    PESSR(N, LINE_COL1) | \
+    PESSR(N, LINE_COL2) | \
+    PESSR(N, LINE_COL3) | \
+    PESSR(N, LINE_COL4) | \
+    PESSR(N, LINE_COL5) | \
+    PESSR(N, LINE_COL6) | \
+    PESSR(N, LINE_COL7) | \
+    PESSR(N, LINE_COL8) | \
+0)
+*/
+
+#define ESSR_BITS_0 (\
+    PESSR_L(LINE_COL1) | \
+    PESSR_L(LINE_COL2) | \
+    PESSR_L(LINE_COL3) | \
+    PESSR_L(LINE_COL4) | \
+0)
+
+#define ESSR_BITS_1 (\
+    PESSR_H(LINE_COL5) | \
+    PESSR_H(LINE_COL6) | \
+    PESSR_H(LINE_COL7) | \
+    PESSR_H(LINE_COL8) | \
+0)
+
 /**
  * @brief   PAL setup.
  * @details Digital I/O ports static configuration as defined in @p board.h.
@@ -183,8 +215,9 @@ const PALConfig pal_default_config = {
         .CFG[0] = AF_BITS(IOPORTE, 0),
         .CFG[1] = AF_BITS(IOPORTE, 1),
     },
-    .ESSR[0] = 0x00000000,
-    .ESSR[1] = 0x00000000,
+    // Enable Column Pins for EXTI
+    .ESSR[0] = ESSR_BITS_0,
+    .ESSR[1] = ESSR_BITS_1,
 };
 
 const ioline_t row_list[MATRIX_ROWS] = {

--- a/keyboards/vortex/boards/VORTEX_DUAL_60/board.h
+++ b/keyboards/vortex/boards/VORTEX_DUAL_60/board.h
@@ -60,7 +60,6 @@
 #define PAD_USART_TX                8
 
 #define LINE_SEL1                   PAL_LINE(IOPORTA, 8)
-#define LINE_SEL2                   PAL_LINE(IOPORTA, 9)
 
 // SPI
 #define LINE_SPI_SCK                PAL_LINE(IOPORTB, 7)
@@ -83,12 +82,25 @@
 #define WIPE_SWITCH_ROW             LINE_DIP4_ROW
 #define WIPE_SWITCH_COL             LINE_DIP4_COL
 
-#define LINE_TPPWR                  PAL_LINE(IOPORTA, 10)   // !
-#define LINE_BLPWM                  PAL_LINE(IOPORTA, 14)   // !
-#define LINE_BLEN                   PAL_LINE(IOPORTA, 15)   // !
-#define LINE_PB0                    PAL_LINE(IOPORTB, 0)    // !
-#define LINE_LED65                  PAL_LINE(IOPORTB, 1)    // !
-#define LINE_TPREQ                  PAL_LINE(IOPORTC, 11)   // !
+/* LED Matrix */
+#define LINE_LED_VOLTAGE            PAL_LINE(IOPORTA, 9)
+#define LINE_OD_RED1                PAL_LINE(IOPORTC, 3)
+#define LINE_OD_RED2                PAL_LINE(IOPORTB, 2)
+#define LINE_OD_RED3                PAL_LINE(IOPORTC, 7)
+#define LINE_TROW1                  PAL_LINE(IOPORTA, 8)
+/* 74LV164 shift register for TROW2-TROW9 */
+#define LINE_LED_SHIFT_DATA         PAL_LINE(IOPORTC, 0)
+#define LINE_LED_SHIFT_CLK          PAL_LINE(IOPORTC, 1)
+#define LINE_LED_SHIFT_CLR          PAL_LINE(IOPORTC, 2)
+
+#define LINE_TCOL1                  PAL_LINE(IOPORTC, 11)
+#define LINE_TCOL2                  PAL_LINE(IOPORTC, 10)
+#define LINE_TCOL3                  PAL_LINE(IOPORTC, 9)
+#define LINE_TCOL4                  PAL_LINE(IOPORTA, 7)
+#define LINE_TCOL5                  PAL_LINE(IOPORTA, 2)
+#define LINE_TCOL6                  PAL_LINE(IOPORTA, 1)
+#define LINE_TCOL7                  PAL_LINE(IOPORTA, 0)
+#define LINE_TCOL8                  PAL_LINE(IOPORTB, 6)
 
 #if !defined(_FROM_ASM_)
 #ifdef __cplusplus

--- a/keyboards/vortex/ht32.c
+++ b/keyboards/vortex/ht32.c
@@ -1,3 +1,4 @@
+#include "hal.h"
 #include "vortex.h"
 
 void firmware_reset(uint32_t key) {

--- a/keyboards/vortex/matrix.c
+++ b/keyboards/vortex/matrix.c
@@ -66,10 +66,19 @@ uint8_t matrix_scan_key(uint32_t row_line, uint32_t col_line) {
     }
 }
 
+__attribute__ ((weak))
+void pok3r_enable_leds(void) {
+};
+
+__attribute__ ((weak))
+void pok3r_disable_leds(void) {
+};
+
 uint8_t matrix_scan(void) {
     // cache of input ports for columns
     static uint16_t port_cache[3];
 
+    pok3r_disable_leds();
     // scan each row
     for (int row = 0; row < MATRIX_ROWS; row++) {
         palClearLine(row_list[row]);
@@ -102,6 +111,7 @@ uint8_t matrix_scan(void) {
         }
     }
 
+    pok3r_enable_leds();
     matrix_scan_quantum();
     return 1;
 }

--- a/keyboards/vortex/mcuconf.h
+++ b/keyboards/vortex/mcuconf.h
@@ -31,19 +31,18 @@
 
 // This configuration:
 // 8 MHz HSE crystal
-// PLL multiplies HSE to 72 MHz core and peripheral clock
-// 72 MHz to UART
+// PLL multiplies HSE to 24 MHz core and peripheral clock
 // 48 MHz to USB
 
 #define HT32_CK_HSE_FREQUENCY   8000000UL           // 8 MHz
 #define HT32_CKCU_SW            CKCU_GCCR_SW_PLL
 #define HT32_PLL_USE_HSE        TRUE
-#define HT32_PLL_FBDIV          18                  // 8 MHz -> 144 MHz
+#define HT32_PLL_FBDIV          6                   // 8 MHz -> 48 MHz
 #define HT32_PLL_OTDIV          0
-#define HT32_AHB_PRESCALER      2                   // 144 MHz -> 72 MHz
-#define HT32_USART_PRESCALER    1                   // 72 MHz
-#define HT32_USB_PRESCALER      3                   // 144 MHz -> 48 MHz
-// SysTick uses processor clock at 72MHz
+#define HT32_AHB_PRESCALER      1                   // 48 -> 48 MHz
+#define HT32_USART_PRESCALER    1                   // 24 MHz
+#define HT32_USB_PRESCALER      1                   // 48 MHz
+// SysTick uses processor clock at 48MHz
 #define HT32_ST_USE_HCLK        TRUE
 
 /*

--- a/keyboards/vortex/pok3r/pok3r_led.c
+++ b/keyboards/vortex/pok3r/pok3r_led.c
@@ -1,0 +1,134 @@
+#include "hal.h"
+
+#include "quantum.h"
+#include "pok3r_led.h"
+
+
+typedef struct {
+  ioline_t row;
+  ioline_t col;
+} led_matrix;
+
+led_matrix blue_matrix[POK3R_SUPPORTED_LEDS] = {
+  {LINE_ROW5, LINE_TCOL8}, // POK3R_LED_BLUE_CAPS_LOCK
+  {LINE_ROW8, LINE_TCOL7}, // POK3R_LED_BLUE_SPACE_LEFT
+  {LINE_ROW9, LINE_TCOL6}, // POK3R_LED_BLUE_SPACE_RIGHT
+};
+
+#define SHIFT_TROW5 0x01
+#define SHIFT_TROW4 0x02
+#define SHIFT_TROW3 0x04
+#define SHIFT_TROW2 0x08
+#define SHIFT_TROW8 0x10
+#define SHIFT_TROW9 0x20
+#define SHIFT_TROW7 0x40
+#define SHIFT_TROW6 0x80
+
+/* red leds are always LINE_ROW4 */
+led_matrix red_matrix[POK3R_SUPPORTED_LEDS] = {
+  {LINE_OD_RED3, SHIFT_TROW7}, // POK3R_LED_RED_CAPS_LOCK
+  {LINE_OD_RED2, SHIFT_TROW2}, // POK3R_LED_RED_SPACE_LEFT
+  {LINE_OD_RED1,  LINE_TROW1}, // POK3R_LED_RED_SPACE_RIGHT
+};
+
+
+static uint8_t pok3r_blue_mask;
+static uint8_t pok3r_red_mask;
+
+void pok3r_led_on(enum pok3r_led led) {
+    if (pok3r_blue_mask == 0 && pok3r_red_mask == 0) {
+        palClearLine(LINE_LED_VOLTAGE); // turn led voltage regulator on
+    }
+    if (led >= POK3R_FIRST_RED_LED) {
+        pok3r_red_mask  |= (1 << (led - POK3R_FIRST_RED_LED));
+    } else {
+        pok3r_blue_mask |= (1 << led);
+    }
+}
+
+void pok3r_led_off(enum pok3r_led led) {
+    if (led >= POK3R_FIRST_RED_LED) {
+        pok3r_red_mask  &= ~(1 << (led - POK3R_FIRST_RED_LED));
+    } else {
+        pok3r_blue_mask &= ~(1 << led);
+    }
+    if (pok3r_blue_mask == 0 && pok3r_red_mask == 0) {
+        palSetLine(LINE_LED_VOLTAGE); // turn led voltage regulator off
+    }
+}
+
+void pok3r_disable_leds(void) {
+    for (int led = 0; led < POK3R_SUPPORTED_LEDS; led++) {
+        /* blue leds */
+        palSetLine(blue_matrix[led].row);
+        palClearLine(blue_matrix[led].col);
+
+        /* red leds*/
+        palSetLine(red_matrix[led].row);
+    }
+    /* red leds */
+    palSetLine(LINE_ROW4);
+    palClearLine(LINE_LED_SHIFT_CLR);
+    palClearLine(LINE_TROW1);
+}
+
+static void _prepare_shift_register(uint8_t shift_val) {
+    palSetLine(LINE_LED_SHIFT_CLR);
+    for (int bit = 0x80; bit > 0; bit >>= 1) {
+        if (shift_val & bit)
+            palSetLine(LINE_LED_SHIFT_DATA);
+        else
+            palClearLine(LINE_LED_SHIFT_DATA);
+        palSetLine(LINE_LED_SHIFT_CLK);
+        palClearLine(LINE_LED_SHIFT_CLK);
+    }
+}
+
+void pok3r_enable_leds(void) {
+    static uint8_t blue_or_red;
+    blue_or_red = !blue_or_red;
+    if (blue_or_red && pok3r_blue_mask) {
+        for (int led = 0; led < POK3R_SUPPORTED_LEDS; led++) {
+            if (pok3r_blue_mask & (1 << led)) {
+                palSetLine(blue_matrix[led].col);
+                palClearLine(blue_matrix[led].row);
+            }
+        }
+    } else if (!blue_or_red && pok3r_red_mask) {
+        uint8_t shift = 0;
+        for (int led = 0; led < POK3R_SUPPORTED_LEDS; led++) {
+            if (pok3r_red_mask & (1 << led)) {
+                if (red_matrix[led].col != LINE_TROW1) {
+                    shift |= red_matrix[led].col;
+                } else {
+                    palSetLine(LINE_TROW1);
+                }
+                palClearLine(red_matrix[led].row);
+            }
+        }
+        _prepare_shift_register(shift);
+        palClearLine(LINE_ROW4);
+    }
+}
+
+void led_set_kb(uint8_t usb_led) {
+    if ((usb_led >> USB_LED_CAPS_LOCK) & 1) {
+        pok3r_led_on(POK3R_LED_RED_CAPS_LOCK);
+    } else {
+        pok3r_led_off(POK3R_LED_RED_CAPS_LOCK);
+    }
+    led_set_user(usb_led);
+}
+
+void pok3r_led_suspend(void) {
+    if (pok3r_blue_mask != 0 || pok3r_red_mask != 0) {
+        pok3r_disable_leds();
+        palSetLine(LINE_LED_VOLTAGE);
+    }
+}
+
+void pok3r_led_wakeup(void) {
+  if (pok3r_blue_mask != 0 || pok3r_red_mask != 0) {
+      palClearLine(LINE_LED_VOLTAGE);
+  }
+}

--- a/keyboards/vortex/pok3r/pok3r_led.h
+++ b/keyboards/vortex/pok3r/pok3r_led.h
@@ -1,0 +1,20 @@
+#ifndef POK3R_LED_H
+#define POK3R_LED_H
+
+#define POK3R_SUPPORTED_LEDS 3
+
+enum pok3r_led {
+  POK3R_LED_BLUE_CAPS_LOCK   = 0x00,
+  POK3R_LED_BLUE_SPACE_LEFT  = 0x01,
+  POK3R_LED_BLUE_SPACE_RIGHT = 0x02,
+  // the pcb supports up to 66 LEDs
+  POK3R_LED_RED_CAPS_LOCK    = 0x42,
+  POK3R_LED_RED_SPACE_LEFT   = 0x43,
+  POK3R_LED_RED_SPACE_RIGHT  = 0x44,
+};
+#define POK3R_FIRST_RED_LED POK3R_LED_RED_CAPS_LOCK
+
+void pok3r_led_on(enum pok3r_led led);
+void pok3r_led_off(enum pok3r_led led);
+
+#endif

--- a/keyboards/vortex/pok3r/rules.mk
+++ b/keyboards/vortex/pok3r/rules.mk
@@ -4,6 +4,7 @@ SRC = \
 	ht32.c \
 	util.c \
 	matrix.c \
+	suspend.c \
 	eeprom.c \
 	pok3r_led.c \
 	backlight.c

--- a/keyboards/vortex/pok3r/rules.mk
+++ b/keyboards/vortex/pok3r/rules.mk
@@ -5,6 +5,7 @@ SRC = \
 	util.c \
 	matrix.c \
 	eeprom.c \
+	pok3r_led.c \
 	backlight.c
 
 LAYOUTS += 60_ansi 60_ansi_split_rshift 60_iso

--- a/keyboards/vortex/suspend.c
+++ b/keyboards/vortex/suspend.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018 lactide
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "hal.h"
+
+#define WAKUPCR_EVWUPIEN_Mask 0x80000000uL
+#define SCR_DEEPSLEEP_Mask 0x04uL
+
+extern ioline_t row_list[MATRIX_ROWS];
+extern ioline_t col_list[MATRIX_COLS];
+
+__attribute__ ((weak))
+void pok3r_led_suspend(void) {
+};
+
+__attribute__ ((weak))
+void pok3r_led_wakeup(void) {
+};
+
+void suspend_power_down(void) {
+    pok3r_led_suspend();
+    /* enable all rows */
+    for (int row = 0; row < MATRIX_ROWS; row++) {
+        palClearLine(row_list[row]);
+    }
+    /* enable EXTI clock */
+    CKCU->APBCCR0 |= CKCU_APBCCR0_EXTIEN;
+    /* enable Event Wakeup Interrupt */
+    NVIC_EnableIRQ(EVWUP_IRQn);
+    /* enable wakeup interrupt */
+    EXTI->WAKUPCR = WAKUPCR_EVWUPIEN_Mask;
+    for (int col = 0; col < MATRIX_COLS; col++) {
+        /* enable event wakeup for all column pads */
+        EXTI->WAKUPCR |= (1 << PAL_PAD(col_list[col]));
+        /* set wakeup polarity to low */
+        EXTI->WAKUPPOLR |= (1 << PAL_PAD(col_list[col]));
+    }
+    /* enable deep sleep */
+    SCB->SCR |= SCR_DEEPSLEEP_Mask;
+    /* enable usb low power mode */
+    USB->CSR |= USBCSR_LPMODE | USBCSR_PDWN;
+    /* sleep */
+    __WFI();
+    /* disable usb low power mode */
+    USB->CSR &= ~(USBCSR_LPMODE | USBCSR_PDWN);
+    /* disable deep sleep */
+    SCB->SCR &= ~SCR_DEEPSLEEP_Mask;
+    /* disable all rows */
+    for (int row = 0; row < MATRIX_ROWS; row++) {
+        palSetLine(row_list[row]);
+    }
+    pok3r_led_wakeup();
+}
+
+OSAL_IRQ_HANDLER(HT32_EVWUP_IRQ_VECTOR) {
+    OSAL_IRQ_PROLOGUE();
+    /* acknowledge interrupt */
+    EXTI->WAKUPFLG |= EXTI->WAKUPFLG;
+    /* disable interrupt */
+    EXTI->WAKUPCR = 0;
+    OSAL_IRQ_EPILOGUE();
+}

--- a/keyboards/vortex/vortex.c
+++ b/keyboards/vortex/vortex.c
@@ -20,6 +20,7 @@
 #include "raw_hid.h"
 #include "debug.h"
 #include "version.h"
+#include "usb_descriptor.h"
 
 #include "vortex.h"
 #include "proto.h"

--- a/keyboards/vortex/vortex.c
+++ b/keyboards/vortex/vortex.c
@@ -450,17 +450,3 @@ void OVERRIDE raw_hid_receive(uint8_t *data_in, uint8_t length) {
 void OVERRIDE console_receive(uint8_t *data, uint8_t length) {
     //printf("Console recv %d\n", length);
 }
-
-void OVERRIDE led_set_kb(uint8_t usb_led) {
-    static uint8_t prev = 0;
-    if (usb_led != prev) {
-        printf("Set LED: %02x\n", usb_led);
-    }
-    prev = usb_led;
-    if ((usb_led >> USB_LED_CAPS_LOCK) & 1) {
-//        palClearLine(LINE_LED65);
-    } else {
-//        palSetLine(LINE_LED65);
-    }
-    led_set_user(usb_led);
-}

--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -25,7 +25,7 @@ void suspend_idle(uint8_t time) {
  *
  * FIXME: needs doc
  */
-void suspend_power_down(void) {
+__attribute__ ((weak)) void suspend_power_down(void) {
 	// TODO: figure out what to power down and how
 	// shouldn't power down TPM/FTM if we want a breathing LED
 	// also shouldn't power down USB

--- a/tmk_core/protocol/chibios/usb_main.c
+++ b/tmk_core/protocol/chibios/usb_main.c
@@ -388,7 +388,7 @@ static void usb_event_cb(USBDriver *usbp, usbevent_t event) {
         sduWakeupHookI(&drivers.array[i].driver);
         chSysUnlockFromISR();
       }
-    suspend_wakeup_init();
+    //suspend_wakeup_init();
 #ifdef SLEEP_LED_ENABLE
     sleep_led_disable();
     // NOTE: converters may not accept this


### PR DESCRIPTION
This decreases the power consumption when the pok3r is running by ~10mA.

Moreover the Deep-Sleep1 power saving mode is used when the host suspends it. It uses the EXTI Wakeup Interrupt to wake up when the user presses a key. The pok3r consumes less then 1mA during Deep Sleep,  which can be tested e.g. by using powertop on Linux to toggle the Tunable "Autosuspend  for USB device POK3R"

Before accepting this pull request, the submodule lib/chibios-contrib should be updated after accepting the outstanding Pull Request for ChibiOS-Contrib.