### PR TITLE
Fix usb resume by host

### DIFF
--- a/keyboards/vortex/suspend.c
+++ b/keyboards/vortex/suspend.c
@@ -42,10 +42,14 @@ void suspend_power_down(void) {
     }
     /* enable deep sleep */
     SCB->SCR |= SCR_DEEPSLEEP_Mask;
+    /* enable usb low power mode */
+    USB->CSR |= USBCSR_LPMODE | USBCSR_PDWN;
     /* sleep */
     __WFI();
+    /* disable usb low power mode */
+    USB->CSR &= ~(USBCSR_LPMODE | USBCSR_PDWN);
     /* disable deep sleep */
-    SCB->SCR &= SCR_DEEPSLEEP_Mask;
+    SCB->SCR &= ~SCR_DEEPSLEEP_Mask;
     /* disable all rows */
     for (int row = 0; row < MATRIX_ROWS; row++) {
         palSetLine(row_list[row]);


### PR DESCRIPTION
The Deep-Sleep flag wasn't disabled and the usb LowPower/PowerDown flags
have to be used. This fixes the issue that the device wasn't resumed properly from the host.

We'll still loose at least the first keypress when the keyboard wakes up with the EXTI interrupt.
This happens because we're dropping the keyboard report if we're already transmitting one. tmk_core directly sends an empty report, which blocks the endpoint for the real report.
