### PR TITLE
Support the LEDs on the pok3r

### DIFF
--- a/keyboards/vortex/boards/VORTEX_DUAL_60/board.c
+++ b/keyboards/vortex/boards/VORTEX_DUAL_60/board.c
@@ -36,6 +36,22 @@
     PBIT(PORT, LINE_ROW8) | \
     PBIT(PORT, LINE_ROW9) | \
     PBIT(PORT, LINE_SPI_CS) | \
+    PBIT(PORT, LINE_LED_SHIFT_DATA) | \
+    PBIT(PORT, LINE_LED_SHIFT_CLK) | \
+    PBIT(PORT, LINE_LED_SHIFT_CLR) | \
+    PBIT(PORT, LINE_TROW1) | \
+    PBIT(PORT, LINE_TCOL1) | \
+    PBIT(PORT, LINE_TCOL2) | \
+    PBIT(PORT, LINE_TCOL3) | \
+    PBIT(PORT, LINE_TCOL4) | \
+    PBIT(PORT, LINE_TCOL5) | \
+    PBIT(PORT, LINE_TCOL6) | \
+    PBIT(PORT, LINE_TCOL7) | \
+    PBIT(PORT, LINE_TCOL8) | \
+    PBIT(PORT, LINE_LED_VOLTAGE) | \
+    PBIT(PORT, LINE_OD_RED1) | \
+    PBIT(PORT, LINE_OD_RED2) | \
+    PBIT(PORT, LINE_OD_RED3) | \
 0)
 
 #define IN_BITS(PORT) (\
@@ -47,6 +63,13 @@
     PBIT(PORT, LINE_COL6) | \
     PBIT(PORT, LINE_COL7) | \
     PBIT(PORT, LINE_COL8) | \
+0)
+
+#define OD_BITS(PORT) (\
+    PBIT(PORT, LINE_LED_VOLTAGE) | \
+    PBIT(PORT, LINE_OD_RED1) | \
+    PBIT(PORT, LINE_OD_RED2) | \
+    PBIT(PORT, LINE_OD_RED3) | \
 0)
 
 #define AF_BITS(PORT, N) (\
@@ -71,6 +94,22 @@
     PAFIO(PORT, N, LINE_SPI_MOSI, AFIO_SPI)  | \
     PAFIO(PORT, N, LINE_SPI_MISO, AFIO_SPI)  | \
     PAFIO(PORT, N, LINE_SPI_CS,   AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_SHIFT_DATA, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_SHIFT_CLK, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_SHIFT_CLR, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TROW1, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL1, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL2, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL3, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL4, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL5, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL6, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL7, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_TCOL8, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_LED_VOLTAGE, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_OD_RED1, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_OD_RED2, AFIO_GPIO) | \
+    PAFIO(PORT, N, LINE_OD_RED3, AFIO_GPIO) | \
 0)
 
 /**
@@ -85,7 +124,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTA),
         .PU = IN_BITS(IOPORTA),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTA),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -98,7 +137,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTB),
         .PU = IN_BITS(IOPORTB),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTB),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -111,7 +150,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTC),
         .PU = IN_BITS(IOPORTC),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTC),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -124,7 +163,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTD),
         .PU = IN_BITS(IOPORTD),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTD),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -137,7 +176,7 @@ const PALConfig pal_default_config = {
         .INE = IN_BITS(IOPORTE),
         .PU = IN_BITS(IOPORTE),
         .PD = 0x0000,
-        .OD = 0x0000,
+        .OD = OD_BITS(IOPORTE),
         .DRV = 0x0000,
         .LOCK = 0x0000,
         .OUT = 0x0000,
@@ -242,4 +281,5 @@ void boardInit(void) {
 #if HAL_USE_UART == TRUE
     uart_init();
 #endif
+    palSetLine(LINE_LED_VOLTAGE); //led voltage off after boot
 }

--- a/keyboards/vortex/boards/VORTEX_DUAL_60/board.h
+++ b/keyboards/vortex/boards/VORTEX_DUAL_60/board.h
@@ -60,7 +60,6 @@
 #define PAD_USART_TX                8
 
 #define LINE_SEL1                   PAL_LINE(IOPORTA, 8)
-#define LINE_SEL2                   PAL_LINE(IOPORTA, 9)
 
 // SPI
 #define LINE_SPI_SCK                PAL_LINE(IOPORTB, 7)
@@ -83,12 +82,25 @@
 #define WIPE_SWITCH_ROW             LINE_DIP4_ROW
 #define WIPE_SWITCH_COL             LINE_DIP4_COL
 
-#define LINE_TPPWR                  PAL_LINE(IOPORTA, 10)   // !
-#define LINE_BLPWM                  PAL_LINE(IOPORTA, 14)   // !
-#define LINE_BLEN                   PAL_LINE(IOPORTA, 15)   // !
-#define LINE_PB0                    PAL_LINE(IOPORTB, 0)    // !
-#define LINE_LED65                  PAL_LINE(IOPORTB, 1)    // !
-#define LINE_TPREQ                  PAL_LINE(IOPORTC, 11)   // !
+/* LED Matrix */
+#define LINE_LED_VOLTAGE            PAL_LINE(IOPORTA, 9)
+#define LINE_OD_RED1                PAL_LINE(IOPORTC, 3)
+#define LINE_OD_RED2                PAL_LINE(IOPORTB, 2)
+#define LINE_OD_RED3                PAL_LINE(IOPORTC, 7)
+#define LINE_TROW1                  PAL_LINE(IOPORTA, 8)
+/* 74LV164 shift register for TROW2-TROW9 */
+#define LINE_LED_SHIFT_DATA         PAL_LINE(IOPORTC, 0)
+#define LINE_LED_SHIFT_CLK          PAL_LINE(IOPORTC, 1)
+#define LINE_LED_SHIFT_CLR          PAL_LINE(IOPORTC, 2)
+
+#define LINE_TCOL1                  PAL_LINE(IOPORTC, 11)
+#define LINE_TCOL2                  PAL_LINE(IOPORTC, 10)
+#define LINE_TCOL3                  PAL_LINE(IOPORTC, 9)
+#define LINE_TCOL4                  PAL_LINE(IOPORTA, 7)
+#define LINE_TCOL5                  PAL_LINE(IOPORTA, 2)
+#define LINE_TCOL6                  PAL_LINE(IOPORTA, 1)
+#define LINE_TCOL7                  PAL_LINE(IOPORTA, 0)
+#define LINE_TCOL8                  PAL_LINE(IOPORTB, 6)
 
 #if !defined(_FROM_ASM_)
 #ifdef __cplusplus

--- a/keyboards/vortex/ht32.c
+++ b/keyboards/vortex/ht32.c
@@ -1,3 +1,4 @@
+#include "hal.h"
 #include "vortex.h"
 
 void firmware_reset(uint32_t key) {

--- a/keyboards/vortex/matrix.c
+++ b/keyboards/vortex/matrix.c
@@ -66,10 +66,19 @@ uint8_t matrix_scan_key(uint32_t row_line, uint32_t col_line) {
     }
 }
 
+__attribute__ ((weak))
+void pok3r_enable_leds(void) {
+};
+
+__attribute__ ((weak))
+void pok3r_disable_leds(void) {
+};
+
 uint8_t matrix_scan(void) {
     // cache of input ports for columns
     static uint16_t port_cache[3];
 
+    pok3r_disable_leds();
     // scan each row
     for (int row = 0; row < MATRIX_ROWS; row++) {
         palClearLine(row_list[row]);
@@ -102,6 +111,7 @@ uint8_t matrix_scan(void) {
         }
     }
 
+    pok3r_enable_leds();
     matrix_scan_quantum();
     return 1;
 }

--- a/keyboards/vortex/pok3r/pok3r_led.c
+++ b/keyboards/vortex/pok3r/pok3r_led.c
@@ -1,0 +1,134 @@
+#include "hal.h"
+
+#include "quantum.h"
+#include "pok3r_led.h"
+
+
+typedef struct {
+  ioline_t row;
+  ioline_t col;
+} led_matrix;
+
+led_matrix blue_matrix[POK3R_SUPPORTED_LEDS] = {
+  {LINE_ROW5, LINE_TCOL8}, // POK3R_LED_BLUE_CAPS_LOCK
+  {LINE_ROW8, LINE_TCOL7}, // POK3R_LED_BLUE_SPACE_LEFT
+  {LINE_ROW9, LINE_TCOL6}, // POK3R_LED_BLUE_SPACE_RIGHT
+};
+
+#define SHIFT_TROW5 0x01
+#define SHIFT_TROW4 0x02
+#define SHIFT_TROW3 0x04
+#define SHIFT_TROW2 0x08
+#define SHIFT_TROW8 0x10
+#define SHIFT_TROW9 0x20
+#define SHIFT_TROW7 0x40
+#define SHIFT_TROW6 0x80
+
+/* red leds are always LINE_ROW4 */
+led_matrix red_matrix[POK3R_SUPPORTED_LEDS] = {
+  {LINE_OD_RED3, SHIFT_TROW7}, // POK3R_LED_RED_CAPS_LOCK
+  {LINE_OD_RED2, SHIFT_TROW2}, // POK3R_LED_RED_SPACE_LEFT
+  {LINE_OD_RED1,  LINE_TROW1}, // POK3R_LED_RED_SPACE_RIGHT
+};
+
+
+static uint8_t pok3r_blue_mask;
+static uint8_t pok3r_red_mask;
+
+void pok3r_led_on(enum pok3r_led led) {
+    if (pok3r_blue_mask == 0 && pok3r_red_mask == 0) {
+        palClearLine(LINE_LED_VOLTAGE); // turn led voltage regulator on
+    }
+    if (led >= POK3R_FIRST_RED_LED) {
+        pok3r_red_mask  |= (1 << (led - POK3R_FIRST_RED_LED));
+    } else {
+        pok3r_blue_mask |= (1 << led);
+    }
+}
+
+void pok3r_led_off(enum pok3r_led led) {
+    if (led >= POK3R_FIRST_RED_LED) {
+        pok3r_red_mask  &= ~(1 << (led - POK3R_FIRST_RED_LED));
+    } else {
+        pok3r_blue_mask &= ~(1 << led);
+    }
+    if (pok3r_blue_mask == 0 && pok3r_red_mask == 0) {
+        palSetLine(LINE_LED_VOLTAGE); // turn led voltage regulator off
+    }
+}
+
+void pok3r_disable_leds(void) {
+    for (int led = 0; led < POK3R_SUPPORTED_LEDS; led++) {
+        /* blue leds */
+        palSetLine(blue_matrix[led].row);
+        palClearLine(blue_matrix[led].col);
+
+        /* red leds*/
+        palSetLine(red_matrix[led].row);
+    }
+    /* red leds */
+    palSetLine(LINE_ROW4);
+    palClearLine(LINE_LED_SHIFT_CLR);
+    palClearLine(LINE_TROW1);
+}
+
+static void _prepare_shift_register(uint8_t shift_val) {
+    palSetLine(LINE_LED_SHIFT_CLR);
+    for (int bit = 0x80; bit > 0; bit >>= 1) {
+        if (shift_val & bit)
+            palSetLine(LINE_LED_SHIFT_DATA);
+        else
+            palClearLine(LINE_LED_SHIFT_DATA);
+        palSetLine(LINE_LED_SHIFT_CLK);
+        palClearLine(LINE_LED_SHIFT_CLK);
+    }
+}
+
+void pok3r_enable_leds(void) {
+    static uint8_t blue_or_red;
+    blue_or_red = !blue_or_red;
+    if (blue_or_red && pok3r_blue_mask) {
+        for (int led = 0; led < POK3R_SUPPORTED_LEDS; led++) {
+            if (pok3r_blue_mask & (1 << led)) {
+                palSetLine(blue_matrix[led].col);
+                palClearLine(blue_matrix[led].row);
+            }
+        }
+    } else if (!blue_or_red && pok3r_red_mask) {
+        uint8_t shift = 0;
+        for (int led = 0; led < POK3R_SUPPORTED_LEDS; led++) {
+            if (pok3r_red_mask & (1 << led)) {
+                if (red_matrix[led].col != LINE_TROW1) {
+                    shift |= red_matrix[led].col;
+                } else {
+                    palSetLine(LINE_TROW1);
+                }
+                palClearLine(red_matrix[led].row);
+            }
+        }
+        _prepare_shift_register(shift);
+        palClearLine(LINE_ROW4);
+    }
+}
+
+void led_set_kb(uint8_t usb_led) {
+    if ((usb_led >> USB_LED_CAPS_LOCK) & 1) {
+        pok3r_led_on(POK3R_LED_RED_CAPS_LOCK);
+    } else {
+        pok3r_led_off(POK3R_LED_RED_CAPS_LOCK);
+    }
+    led_set_user(usb_led);
+}
+
+void pok3r_led_suspend(void) {
+    if (pok3r_blue_mask != 0 || pok3r_red_mask != 0) {
+        pok3r_disable_leds();
+        palSetLine(LINE_LED_VOLTAGE);
+    }
+}
+
+void pok3r_led_wakeup(void) {
+  if (pok3r_blue_mask != 0 || pok3r_red_mask != 0) {
+      palClearLine(LINE_LED_VOLTAGE);
+  }
+}

--- a/keyboards/vortex/pok3r/pok3r_led.h
+++ b/keyboards/vortex/pok3r/pok3r_led.h
@@ -1,0 +1,20 @@
+#ifndef POK3R_LED_H
+#define POK3R_LED_H
+
+#define POK3R_SUPPORTED_LEDS 3
+
+enum pok3r_led {
+  POK3R_LED_BLUE_CAPS_LOCK   = 0x00,
+  POK3R_LED_BLUE_SPACE_LEFT  = 0x01,
+  POK3R_LED_BLUE_SPACE_RIGHT = 0x02,
+  // the pcb supports up to 66 LEDs
+  POK3R_LED_RED_CAPS_LOCK    = 0x42,
+  POK3R_LED_RED_SPACE_LEFT   = 0x43,
+  POK3R_LED_RED_SPACE_RIGHT  = 0x44,
+};
+#define POK3R_FIRST_RED_LED POK3R_LED_RED_CAPS_LOCK
+
+void pok3r_led_on(enum pok3r_led led);
+void pok3r_led_off(enum pok3r_led led);
+
+#endif

--- a/keyboards/vortex/pok3r/rules.mk
+++ b/keyboards/vortex/pok3r/rules.mk
@@ -5,6 +5,7 @@ SRC = \
 	util.c \
 	matrix.c \
 	eeprom.c \
+	pok3r_led.c \
 	backlight.c
 
 LAYOUTS += 60_ansi 60_ansi_split_rshift 60_iso

--- a/keyboards/vortex/vortex.c
+++ b/keyboards/vortex/vortex.c
@@ -20,6 +20,7 @@
 #include "raw_hid.h"
 #include "debug.h"
 #include "version.h"
+#include "usb_descriptor.h"
 
 #include "vortex.h"
 #include "proto.h"

--- a/keyboards/vortex/vortex.c
+++ b/keyboards/vortex/vortex.c
@@ -450,17 +450,3 @@ void OVERRIDE raw_hid_receive(uint8_t *data_in, uint8_t length) {
 void OVERRIDE console_receive(uint8_t *data, uint8_t length) {
     //printf("Console recv %d\n", length);
 }
-
-void OVERRIDE led_set_kb(uint8_t usb_led) {
-    static uint8_t prev = 0;
-    if (usb_led != prev) {
-        printf("Set LED: %02x\n", usb_led);
-    }
-    prev = usb_led;
-    if ((usb_led >> USB_LED_CAPS_LOCK) & 1) {
-//        palClearLine(LINE_LED65);
-    } else {
-//        palSetLine(LINE_LED65);
-    }
-    led_set_user(usb_led);
-}


### PR DESCRIPTION
I've added basic support for the LEDs on a pok3r.   I haven't implemented the whole matrix, since i don't plan to modify my PCB with more LEDs.
The schematics in vortex-keyboards are not complete since some not connected pins have to be used to turn on the red leds.